### PR TITLE
Restructure iqp migration guide

### DIFF
--- a/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx
+++ b/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx
@@ -101,30 +101,8 @@ Follow these steps to set up the new version of IBM Quantum Platform.
 
 <span id="access"></span>
 ### Access
-
-#### Trusted Machine
 Once the onboarding steps are complete, you can now use your API key (`token` parameter) and, optionally, instance CRN (`instance` parameter) to instantiate a `QiskitRuntimeService` in your Python virtual environment.  See the [installation instructions](/docs/guides/install-qiskit#local) if you do not already have a virtual environment set up.
 To copy the instance CRN, go to your [dashboard,](https://quantum.cloud.ibm.com/) go to [Instances,](https://quantum.cloud.ibm.com/instances) and click the copy icon at the end of the instance's row. The instance name listed in the first column can also be used. If an instance is not specified, all instances in your account will be available.
-
-    <span id="save-account"></span>**If you are working in a trusted Python environment (such as on a personal laptop or workstation),** use the `save_account()` method to save your credentials locally. ([Skip to the next step](#untrusted-machine) if you are not using a trusted environment, such as a shared or public computer, to authenticate to IBM Quantum Platform.) To use `save_account()`, run `python` in your shell, then enter the following:
-
-    ```python
-    token = "<your-API-token>"
-    ```
-
-    ```python
-    from qiskit_ibm_runtime import QiskitRuntimeService
-
-    QiskitRuntimeService.save_account(
-      token=token,
-      channel="ibm_quantum_platform", # `channel` distinguishes between different account types.
-      instance="instance-CRN or instance-name", # Optionally copy the instance CRN or name from the Instance section on the dashboard.
-      name="account-name", # Optionally name this set of credentials.
-      overwrite=True # Only needed if you already have Cloud credentials.
-      set_as_default=True # Only needed if you want these credentials to be used as the default account. 
-      # This is recommended if you have an IQP classic account set as the default. 
-    )
-    ```
 
 Setup details:
    <Admonition type="note">
@@ -140,21 +118,42 @@ Setup details:
    * If you have access to multiple accounts, only one account per API token can be used. The
    IBM Cloud API Token is treated as the account identifier and will unlock the resources associated with the account the token was created in. A list of your tokens per account can be found on the [API keys](https://cloud.ibm.com/iam/apikeys) page.
 
-   Run `exit()` to close the Python shell. From now on, whenever you need to authenticate to the service, you can load your credentials with `QiskitRuntimeService()`.
+#### Trusted Machine
+<span id="save-account"></span>**If you are working in a trusted Python environment (such as on a personal laptop or workstation),** use the `save_account()` method to save your credentials locally. ([Skip to the next step](#untrusted-machine) if you are not using a trusted environment, such as a shared or public computer, to authenticate to IBM Quantum Platform.) To use `save_account()`, run `python` in your shell, then enter the following:
 
-   ```python
-   # Load default saved credentials
-   service = QiskitRuntimeService()
-   ```
-   ```python
-   # Load saved credentials if you specified a name
-   service = QiskitRuntimeService(name="account-name")
-   ```
+```python
+token = "<your-API-token>"
+```
 
-   * If you previously saved an IBM Quantum Platform Classic account as the default, specify `set_as_default=True` for your new account when you use the `save_account()` method.
-   * If no accounts are saved as the default, an account saved on the new IBM Quantum Platform with `ibm_quantum_platform` as the channel name will be used as the default when initializing your account. `set_as_default=True` can still be used to set an account with a certain configuration of credentials as the default.
-   * If you are saving multiple accounts per channel, consider using the `name` parameter to differentiate them.
-   * Credentials are saved to `$HOME/.qiskit/qiskit-ibm.json`.  Do not manually edit this file.
+```python
+from qiskit_ibm_runtime import QiskitRuntimeService
+
+QiskitRuntimeService.save_account(
+token=token,
+channel="ibm_quantum_platform", # `channel` distinguishes between different account types.
+instance="instance-CRN or instance-name", # Optionally copy the instance CRN or name from the Instance section on the dashboard.
+name="account-name", # Optionally name this set of credentials.
+overwrite=True # Only needed if you already have Cloud credentials.
+set_as_default=True # Only needed if you want these credentials to be used as the default account. 
+# This is recommended if you have an IQP classic account set as the default. 
+)
+```
+
+Run `exit()` to close the Python shell. From now on, whenever you need to authenticate to the service, you can load your credentials with `QiskitRuntimeService()`.
+
+```python
+# Load default saved credentials
+service = QiskitRuntimeService()
+```
+```python
+# Load saved credentials if you specified a name
+service = QiskitRuntimeService(name="account-name")
+```
+
+* If you previously saved an IBM Quantum Platform Classic account as the default, specify `set_as_default=True` for your new account when you use the `save_account()` method.
+* If no accounts are saved as the default, an account saved on the new IBM Quantum Platform with `ibm_quantum_platform` as the channel name will be used as the default when initializing your account. `set_as_default=True` can still be used to set an account with a certain configuration of credentials as the default.
+* If you are saving multiple accounts per channel, consider using the `name` parameter to differentiate them.
+* Credentials are saved to `$HOME/.qiskit/qiskit-ibm.json`.  Do not manually edit this file.
 
 <span id="untrusted-machine"></span>
 #### Untrusted Machine

--- a/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx
+++ b/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx
@@ -76,9 +76,9 @@ Jobs that were run on IBM Quantum Platform Classic will not be available after t
 <span id="onboard"></span>
 ### Onboard
 
-Follow these steps to start using the new version of IBM Quantum Platform.
+Follow these steps to set up the new version of IBM Quantum Platform.
 
-1. If you don't already have one, [register for an IBM Cloud account.](https://quantum.cloud.ibm.com/registration) If you already have an IBM Quantum Platform account, use the same email for this account.
+1. If you don't already have one, [register for an IBM Cloud account.](https://quantum.cloud.ibm.com/registration) If you already have an IBM Quantum Platform Classic account, use the same email for this account.
 2. Create an instance.
    1. Log on to the new [IBM Quantum Platform.](https://quantum.cloud.ibm.com) Choose **IBMid** and enter your IBM Cloud account information. The dashboard opens.
    1. If you do not already have an instance, Click **Create instance** on the dashboard page.
@@ -98,8 +98,13 @@ Follow these steps to start using the new version of IBM Quantum Platform.
    <Admonition type="note">
    This API key is only visible for a short amount of time so be sure to store it in a safe place.  To manage your API key, use IBM Cloud.  See [Managing user API keys](https://cloud.ibm.com/docs/account?topic=account-userapikey) for instructions.
    </Admonition>
-4. Use your API key to activate your Python virtual environment.  See the [installation instructions](/docs/guides/install-qiskit#local) if you do not already have a virtual environment set up.
 
+<span id="access"></span>
+### Access
+
+#### Trusted Machine
+Once the onboarding steps are complete, you can now use your API key (`token` parameter) and, optionally, instance CRN (`instance` parameter) to instantiate a `QiskitRuntimeService` in your Python virtual environment.  See the [installation instructions](/docs/guides/install-qiskit#local) if you do not already have a virtual environment set up.
+To copy the instance CRN, go to your [dashboard,](https://quantum.cloud.ibm.com/) go to [Instances,](https://quantum.cloud.ibm.com/instances) and click the copy icon at the end of the instance's row. The instance name listed in the first column can also be used. If an instance is not specified, all instances in your account will be available.
 
     <span id="save-account"></span>**If you are working in a trusted Python environment (such as on a personal laptop or workstation),** use the `save_account()` method to save your credentials locally. ([Skip to the next step](#untrusted-machine) if you are not using a trusted environment, such as a shared or public computer, to authenticate to IBM Quantum Platform.) To use `save_account()`, run `python` in your shell, then enter the following:
 
@@ -121,47 +126,52 @@ Follow these steps to start using the new version of IBM Quantum Platform.
     )
     ```
 
-   * The new channel name is `ibm_quantum_platform`. If you previously set your default channel to `ibm_quantum` in your saved credentials, you need to update that setting. If you were previously working with Qiskit Runtime on IBM Cloud, you can skip this.
+<Admonition type="note">
+* The new channel name is `ibm_quantum_platform`. If you previously set your default channel to `ibm_quantum` in your saved credentials, you need to update that setting. If you were previously working with Qiskit Runtime on IBM Cloud, you can skip this.
 
-   Note that it is not required to pass in an instance when saving an account or initializing the `QiskitRuntimeService()`. If an instance is not passed in, all instances will be checked when a backend is retrieved (`service.backend("backend_name")`). If an instance is passed into `save_account()`, or passed in during initialization, it is used as the default instance when retrieving backends. An instance passed in at initialization takes precedence over the one saved in the account. To copy the instance CRN, go to [Instances](https://quantum.cloud.ibm.com/instances) and click the copy icon at the end of the instance's row.
+* It is not required to pass in an instance when saving an account or initializing the `QiskitRuntimeService()`. If an instance is not passed in, all instances will be checked when a backend is retrieved (`service.backend("backend_name")`). If an instance is passed into `save_account()`, or passed in during initialization, it is used as the default instance when retrieving backends. An instance passed in at initialization takes precedence over the one saved in the account. To copy the instance CRN, go to [Instances](https://quantum.cloud.ibm.com/instances) and click the copy icon at the end of the instance's row.
+</Admonition>
 
-      * New parameters, `region`, and `plans_preference`, have been added to the `QiskitRuntimeService()` initializer and the `save_account()` method. These can be used to prioritize certain instances on the new platform (`ibm_quantum_platform`, and temporarily, `ibm_cloud` channels) without explicitly providing the CRN.
-      `region` allows you to set a region preference (`us-east` or `eu-de`), For example, if `us-east` is specified,
-      then only instances from `us-east` will be checked. `plans_preference` takes a list of plans where instances will be prioritized in the order of plans given. For example, `['Open', 'Premium']` would prioritize all Open Plan instances, then all Premium Plan instances, and then the rest.
-      * In addition to the IBM Cloud Resource Name (CRN), the instance name can also be passed in as the instance value.
-      * If you have access to multiple accounts, only one account per API token can be used. The
-      IBM Cloud API Token is treated as the account identifier and will unlock the resources associated with the account the token was created in. A list of your tokens per account can be found on the [API keys](https://cloud.ibm.com/iam/apikeys) page.
+* New parameters, `region`, and `plans_preference`, have been added to the `QiskitRuntimeService()` initializer and the `save_account()` method. These can be used to prioritize certain instances on the new platform (`ibm_quantum_platform`, and temporarily, `ibm_cloud` channels) without explicitly providing the CRN.
+`region` allows you to set a region preference (`us-east` or `eu-de`), For example, if `us-east` is specified,
+then only instances from `us-east` will be checked. `plans_preference` takes a list of plans where instances will be prioritized in the order of plans given. For example, `['Open', 'Premium']` would prioritize all Open Plan instances, then all Premium Plan instances, and then the rest.
+* In addition to the IBM Cloud Resource Name (CRN), the instance name can also be passed in as the instance value.
+* If you have access to multiple accounts, only one account per API token can be used. The
+IBM Cloud API Token is treated as the account identifier and will unlock the resources associated with the account the token was created in. A list of your tokens per account can be found on the [API keys](https://cloud.ibm.com/iam/apikeys) page.
 
-    Run `exit()` to close the Python shell. From now on, whenever you need to authenticate to the service, you can load your credentials with `QiskitRuntimeService()`.
+Run `exit()` to close the Python shell. From now on, whenever you need to authenticate to the service, you can load your credentials with `QiskitRuntimeService()`.
 
-    ```python
-    # Load default saved credentials
-    service = QiskitRuntimeService()
-    ```
-    ```python
-    # Load saved credentials if you specified a name
-    service = QiskitRuntimeService(name="account-name")
-    ```
+```python
+# Load default saved credentials
+service = QiskitRuntimeService()
+```
+```python
+# Load saved credentials if you specified a name
+service = QiskitRuntimeService(name="account-name")
+```
 
-      * If you previously saved an IBM Quantum Platform Classic account as the default, specify `set_as_default=True` for your new account when you use the `save_account()` method.
-      * If no accounts are saved as the default, an account saved on the new IBM Quantum Platform with `ibm_quantum_platform` as the channel name will be used as the default when initializing your account. `set_as_default=True` can still be used to set an account with a certain configuration of credentials as the default.
-      * If you are saving multiple accounts per channel, consider using the `name` parameter to differentiate them.
-      * Credentials are saved to `$HOME/.qiskit/qiskit-ibm.json`.  Do not manually edit this file.
-5. <span id="untrusted-machine"></span>**Avoid executing code on an untrusted machine or an external cloud Python environment to minimize security risks.** If you must use an untrusted environment (for example, a public computer), change your API key after each use by following the instructions in the [Delete an API key](https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui#delete_user_key) section to reduce risk. To initialize the service in this situation, you can use code like the following:
+* If you previously saved an IBM Quantum Platform Classic account as the default, specify `set_as_default=True` for your new account when you use the `save_account()` method.
+* If no accounts are saved as the default, an account saved on the new IBM Quantum Platform with `ibm_quantum_platform` as the channel name will be used as the default when initializing your account. `set_as_default=True` can still be used to set an account with a certain configuration of credentials as the default.
+* If you are saving multiple accounts per channel, consider using the `name` parameter to differentiate them.
+* Credentials are saved to `$HOME/.qiskit/qiskit-ibm.json`.  Do not manually edit this file.
 
-    ```python
-    from qiskit_ibm_runtime import QiskitRuntimeService
+<span id="untrusted-machine"></span>
+#### Untrusted Machine
+**Avoid executing code on an untrusted machine or an external cloud Python environment to minimize security risks.** If you must use an untrusted environment (for example, a public computer), change your API key after each use by following the instructions in the [Delete an API key](https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui#delete_user_key) section to reduce risk. To initialize the service in this situation, you can use code like the following:
 
-    # After using the following code, go to the IBM Cloud API keys page (https://cloud.ibm.com/iam/apikeys)
-    # and disable your API key (click Enabled slider in the API key field)
-    service = QiskitRuntimeService(channel="ibm_quantum_platform", token="<MY_IBM_QUANTUM_TOKEN>", instance="<MY_INSTANCE_CRN or name>")
-    ```
+```python
+from qiskit_ibm_runtime import QiskitRuntimeService
 
-    <Admonition type="caution">
-      When sharing code with others, ensure that your API key is not embedded directly within the Python script. Instead, share the script without the token and provide instructions for securely setting it up.
+# After using the following code, go to the IBM Cloud API keys page (https://cloud.ibm.com/iam/apikeys)
+# and disable your API key (click Enabled slider in the API key field)
+service = QiskitRuntimeService(channel="ibm_quantum_platform", token="<MY_IBM_QUANTUM_TOKEN>", instance="<MY_INSTANCE_CRN or name>")
+```
 
-      If you accidentally share your key with someone or include it in version control like Git, immediately revoke your key by following these instructions to [delete an API key](https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui#delete_user_key) to reduce risk.
-    </Admonition>
+<Admonition type="caution">
+When sharing code with others, ensure that your API key is not embedded directly within the Python script. Instead, share the script without the token and provide instructions for securely setting it up.
+
+If you accidentally share your key with someone or include it in version control like Git, immediately revoke your key by following these instructions to [delete an API key](https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui#delete_user_key) to reduce risk.
+</Admonition>
 
 ## Current Qiskit Runtime on IBM Cloud users
 

--- a/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx
+++ b/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx
@@ -126,34 +126,35 @@ To copy the instance CRN, go to your [dashboard,](https://quantum.cloud.ibm.com/
     )
     ```
 
-<Admonition type="note">
-* The new channel name is `ibm_quantum_platform`. If you previously set your default channel to `ibm_quantum` in your saved credentials, you need to update that setting. If you were previously working with Qiskit Runtime on IBM Cloud, you can skip this.
+Setup details:
+   <Admonition type="note">
+   * The new channel name is `ibm_quantum_platform`. If you previously set your default channel to `ibm_quantum` in your saved credentials, you need to update that setting. If you were previously working with Qiskit Runtime on IBM Cloud, you can skip this.
 
-* It is not required to pass in an instance when saving an account or initializing the `QiskitRuntimeService()`. If an instance is not passed in, all instances will be checked when a backend is retrieved (`service.backend("backend_name")`). If an instance is passed into `save_account()`, or passed in during initialization, it is used as the default instance when retrieving backends. An instance passed in at initialization takes precedence over the one saved in the account. To copy the instance CRN, go to [Instances](https://quantum.cloud.ibm.com/instances) and click the copy icon at the end of the instance's row.
-</Admonition>
+   * It is not required to pass in an instance when saving an account or initializing the `QiskitRuntimeService()`. If an instance is not passed in, all instances will be checked when a backend is retrieved (`service.backend("backend_name")`). If an instance is passed into `save_account()`, or passed in during initialization, it is used as the default instance when retrieving backends. An instance passed in at initialization takes precedence over the one saved in the account. To copy the instance CRN, go to [Instances](https://quantum.cloud.ibm.com/instances) and click the copy icon at the end of the instance's row.
+   </Admonition>
 
-* New parameters, `region`, and `plans_preference`, have been added to the `QiskitRuntimeService()` initializer and the `save_account()` method. These can be used to prioritize certain instances on the new platform (`ibm_quantum_platform`, and temporarily, `ibm_cloud` channels) without explicitly providing the CRN.
-`region` allows you to set a region preference (`us-east` or `eu-de`), For example, if `us-east` is specified,
-then only instances from `us-east` will be checked. `plans_preference` takes a list of plans where instances will be prioritized in the order of plans given. For example, `['Open', 'Premium']` would prioritize all Open Plan instances, then all Premium Plan instances, and then the rest.
-* In addition to the IBM Cloud Resource Name (CRN), the instance name can also be passed in as the instance value.
-* If you have access to multiple accounts, only one account per API token can be used. The
-IBM Cloud API Token is treated as the account identifier and will unlock the resources associated with the account the token was created in. A list of your tokens per account can be found on the [API keys](https://cloud.ibm.com/iam/apikeys) page.
+   * New parameters, `region`, and `plans_preference`, have been added to the `QiskitRuntimeService()` initializer and the `save_account()` method. These can be used to prioritize certain instances on the new platform (`ibm_quantum_platform`, and temporarily, `ibm_cloud` channels) without explicitly providing the CRN.
+   `region` allows you to set a region preference (`us-east` or `eu-de`), For example, if `us-east` is specified,
+   then only instances from `us-east` will be checked. `plans_preference` takes a list of plans where instances will be prioritized in the order of plans given. For example, `['Open', 'Premium']` would prioritize all Open Plan instances, then all Premium Plan instances, and then the rest.
+   * In addition to the IBM Cloud Resource Name (CRN), the instance name can also be passed in as the instance value.
+   * If you have access to multiple accounts, only one account per API token can be used. The
+   IBM Cloud API Token is treated as the account identifier and will unlock the resources associated with the account the token was created in. A list of your tokens per account can be found on the [API keys](https://cloud.ibm.com/iam/apikeys) page.
 
-Run `exit()` to close the Python shell. From now on, whenever you need to authenticate to the service, you can load your credentials with `QiskitRuntimeService()`.
+   Run `exit()` to close the Python shell. From now on, whenever you need to authenticate to the service, you can load your credentials with `QiskitRuntimeService()`.
 
-```python
-# Load default saved credentials
-service = QiskitRuntimeService()
-```
-```python
-# Load saved credentials if you specified a name
-service = QiskitRuntimeService(name="account-name")
-```
+   ```python
+   # Load default saved credentials
+   service = QiskitRuntimeService()
+   ```
+   ```python
+   # Load saved credentials if you specified a name
+   service = QiskitRuntimeService(name="account-name")
+   ```
 
-* If you previously saved an IBM Quantum Platform Classic account as the default, specify `set_as_default=True` for your new account when you use the `save_account()` method.
-* If no accounts are saved as the default, an account saved on the new IBM Quantum Platform with `ibm_quantum_platform` as the channel name will be used as the default when initializing your account. `set_as_default=True` can still be used to set an account with a certain configuration of credentials as the default.
-* If you are saving multiple accounts per channel, consider using the `name` parameter to differentiate them.
-* Credentials are saved to `$HOME/.qiskit/qiskit-ibm.json`.  Do not manually edit this file.
+   * If you previously saved an IBM Quantum Platform Classic account as the default, specify `set_as_default=True` for your new account when you use the `save_account()` method.
+   * If no accounts are saved as the default, an account saved on the new IBM Quantum Platform with `ibm_quantum_platform` as the channel name will be used as the default when initializing your account. `set_as_default=True` can still be used to set an account with a certain configuration of credentials as the default.
+   * If you are saving multiple accounts per channel, consider using the `name` parameter to differentiate them.
+   * Credentials are saved to `$HOME/.qiskit/qiskit-ibm.json`.  Do not manually edit this file.
 
 <span id="untrusted-machine"></span>
 #### Untrusted Machine

--- a/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx
+++ b/docs/migration-guides/classic-iqp-to-cloud-iqp.mdx
@@ -115,8 +115,7 @@ Setup details:
    `region` allows you to set a region preference (`us-east` or `eu-de`), For example, if `us-east` is specified,
    then only instances from `us-east` will be checked. `plans_preference` takes a list of plans where instances will be prioritized in the order of plans given. For example, `['Open', 'Premium']` would prioritize all Open Plan instances, then all Premium Plan instances, and then the rest.
    * In addition to the IBM Cloud Resource Name (CRN), the instance name can also be passed in as the instance value.
-   * If you have access to multiple accounts, only one account per API token can be used. The
-   IBM Cloud API Token is treated as the account identifier and will unlock the resources associated with the account the token was created in. A list of your tokens per account can be found on the [API keys](https://cloud.ibm.com/iam/apikeys) page.
+   * If you have access to multiple accounts, only one account per API token can be used. The IBM Cloud API Token is treated as the account identifier and will unlock the resources associated with the account the token was created in. A list of your tokens per account can be found on the [API keys](https://cloud.ibm.com/iam/apikeys) page.
 
 #### Trusted Machine
 <span id="save-account"></span>**If you are working in a trusted Python environment (such as on a personal laptop or workstation),** use the `save_account()` method to save your credentials locally. ([Skip to the next step](#untrusted-machine) if you are not using a trusted environment, such as a shared or public computer, to authenticate to IBM Quantum Platform.) To use `save_account()`, run `python` in your shell, then enter the following:
@@ -129,13 +128,13 @@ token = "<your-API-token>"
 from qiskit_ibm_runtime import QiskitRuntimeService
 
 QiskitRuntimeService.save_account(
-token=token,
-channel="ibm_quantum_platform", # `channel` distinguishes between different account types.
-instance="instance-CRN or instance-name", # Optionally copy the instance CRN or name from the Instance section on the dashboard.
-name="account-name", # Optionally name this set of credentials.
-overwrite=True # Only needed if you already have Cloud credentials.
-set_as_default=True # Only needed if you want these credentials to be used as the default account. 
-# This is recommended if you have an IQP classic account set as the default. 
+   token=token,
+   channel="ibm_quantum_platform", # `channel` distinguishes between different account types.
+   instance="instance-CRN or instance-name", # Optionally copy the instance CRN or name from the Instance section on the dashboard.
+   name="account-name", # Optionally name this set of credentials.
+   overwrite=True # Only needed if you already have Cloud credentials.
+   set_as_default=True # Only needed if you want these credentials to be used as the default account. 
+   # This is recommended if you have an IQP classic account set as the default. 
 )
 ```
 


### PR DESCRIPTION
This is a proposal for flattening the guide structure and adding titles to make it easier to follow. I found the original guide too nested and filled with enumerations that made it difficult to understand which step was for what. In this proposal, there are clear separations between the IQP setup section (on the browser) and the runtime setup section (on the Python environment).